### PR TITLE
Minor fixes to examples in `README.md` and at the top of the `kb_text_shape.h`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,11 @@ void SegmentText(uint32_t *Codepoints, size_t CodepointCount)
     kbts_break Break;
     while(kbts_Break(&BreakState, &Break))
     {
-      if((Break.Position > RunStart) && (Break.Flags & KBTS_BREAK_FLAG_DIRECTION | KBTS_BREAK_FLAG_SCRIPT | KBTS_BREAK_FLAG_LINE_HARD))
+      if((Break.Position > RunStart) && (Break.Flags & (KBTS_BREAK_FLAG_DIRECTION | KBTS_BREAK_FLAG_SCRIPT | KBTS_BREAK_FLAG_LINE_HARD)))
       {
         size_t RunLength = Break.Position - RunStart;
         ShapeText(&Cursor, Codepoints + RunStart, RunLength, BreakState.MainDirection, Direction, Script);
+        RunStart = Break.Position;
       }
 
       if(Break.Flags & KBTS_BREAK_FLAG_DIRECTION)

--- a/kb_text_shape.h
+++ b/kb_text_shape.h
@@ -98,7 +98,7 @@
        kbts_direction Direction = KBTS_DIRECTION_NONE;
        for(size_t StringAt = 0; StringAt < Length;)
        {
-         kbts_decode Decode = kbts_DecodeUtf8(String, Length - StringAt);
+         kbts_decode Decode = kbts_DecodeUtf8(String + StringAt, Length - StringAt);
          StringAt += Decode.SourceCharactersConsumed;
          if(Decode.Valid)
          {


### PR DESCRIPTION
1. In `kb_text_shape.h` example usage: advancing the string pointer for decoding.
2. In `README.md` example: fixed bitwise operator precedence and updating `RunStart`