### PR TITLE
Only define `KBTS_MEMSET` and `KBTS_MEMCPY` if `KB_TEXT_SHAPE_NO_CRT` is not defined

### DIFF
--- a/kb_text_shape.h
+++ b/kb_text_shape.h
@@ -3956,14 +3956,18 @@ KBTS_EXPORT kbts_script kbts_ScriptTagToScript(kbts_script_tag Tag);
 #include <stdio.h>
 #endif
 
+#ifndef KB_TEXT_SHAPE_NO_CRT
 #ifndef KBTS_MEMSET
 #include <string.h>
 #define KBTS_MEMSET memset
 #endif
+#endif
 
+#ifndef KB_TEXT_SHAPE_NO_CRT
 #ifndef KBTS_MEMCPY
 #include <string.h>
 #define KBTS_MEMCPY memcpy
+#endif
 #endif
 
 #ifndef KB_TEXT_SHAPE_NO_CRT


### PR DESCRIPTION
Hi,
The documentation at the start of the file says to define both `KBTS_MEMSET` and `KBTS_MEMCPY` when using `KB_TEXT_SHAPE_NO_CRT`. I'm not sure if you wanted a compilation error or for it to default to the crt versions if the user fails to define them.