### PR TITLE
Fix Recompose Glyph memory leak and Reuse ShapeConfig

### DIFF
--- a/kb_text_shape.h
+++ b/kb_text_shape.h
@@ -22639,7 +22639,6 @@ static void kbts__ExecuteOp(kbts_shape_scratchpad *Scratchpad, kbts_glyph_storag
                   ParentGlyph.Config = LastBase->Config;
 
                   kbts_glyph *Next = Glyph->Next;
-                  //KBTS__DLLIST_REMOVE(Glyph);
                   kbts__FreeGlyph(Scratchpad, Config, Storage, Glyph);
                   Glyph = Next;
 
@@ -27119,7 +27118,7 @@ static kbts_shape_config *kbts__FindOrCreateShapeConfig(kbts_shape_context *Cont
   
   if(!Result)
   {
-    Result = kbts_CreateShapeConfig(Font, Script, Language, kbts__ArenaAllocator, &&Context->ConfigArena);
+    Result = kbts_CreateShapeConfig(Font, Script, Language, kbts__ArenaAllocator, &Context->ConfigArena);
 
     if(Context->ExistingShapeConfigCount < KBTS__ARRAY_LENGTH(Context->ExistingShapeConfigs))
     {


### PR DESCRIPTION
This is my suggestion for a fix to some memory leaks I encountered when using the Context API. More information in this issue: https://github.com/JimmyLefevre/kb/issues/52.

I am not familiar enough with the code to be confident that this solution won't cause other problems, so I'd need feedback.

Edit: Sorry for the newline changes at the start, I assume it is crlf -> lf.